### PR TITLE
PR: QA중 발견한 사항에 대한 수정

### DIFF
--- a/Up/Up/Features/Company/Entity/Company.swift
+++ b/Up/Up/Features/Company/Entity/Company.swift
@@ -24,7 +24,7 @@ struct Address: Equatable {
 
 extension Address {
     var displayText: String {
-        roadNameAddress.isEmpty ? lotNumberAddress : roadNameAddress
+        lotNumberAddress.isEmpty ? roadNameAddress : lotNumberAddress
     }
 }
 

--- a/Up/Up/Features/Company/Feature/CommentsWindowFeature.swift
+++ b/Up/Up/Features/Company/Feature/CommentsWindowFeature.swift
@@ -386,26 +386,18 @@ struct CommentsWindowView: View {
         }
     }
     
-    @ViewBuilder
     private var enterCommentButton: some View {
-        if store.isValidInput {
-            Button {
-                store.send(.enterCommentButtonTapped)
-            } label: {
-                enterButtonIcon
-            }
-        } else {
-            enterButtonIcon
+        Button {
+            store.send(.enterCommentButtonTapped)
+        } label: {
+            AppIcon.sendFill.image(
+                width: 28,
+                height: 28,
+                appColor: store.isValidInput ? .orange40 : .gray50
+            )
+            .padding(10)
         }
-    }
-    
-    private var enterButtonIcon: some View {
-        AppIcon.sendFill.image(
-            width: 28,
-            height: 28,
-            appColor: store.isValidInput ? .orange40 : .gray50
-        )
-        .padding(10)
+        .disabled(!store.isValidInput)
     }
 }
 

--- a/Up/Up/Features/Company/Feature/CommentsWindowFeature.swift
+++ b/Up/Up/Features/Company/Feature/CommentsWindowFeature.swift
@@ -87,6 +87,7 @@ struct CommentsWindowFeature {
     }
     
     @Dependency(\.reviewService) var reviewService
+    @Dependency(\.validator) var validator
     
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -149,7 +150,8 @@ struct CommentsWindowFeature {
                 if newValue.hasPrefix(state.prefix) == false {
                     state.text = oldValue
                 } else {
-                    state.content = String(newValue.dropFirst(state.prefix.count))
+                    state.content = validator(state.content, String(newValue.dropFirst(state.prefix.count)))
+                    state.text = state.prefix + state.content
                 }
                 return .none
                 
@@ -384,17 +386,26 @@ struct CommentsWindowView: View {
         }
     }
     
+    @ViewBuilder
     private var enterCommentButton: some View {
-        Button {
-            store.send(.enterCommentButtonTapped)
-        } label: {
-            AppIcon.sendFill.image(
-                width: 28,
-                height: 28,
-                appColor: store.isValidInput ? .orange40 : .gray50
-            )
-            .padding(10)
+        if store.isValidInput {
+            Button {
+                store.send(.enterCommentButtonTapped)
+            } label: {
+                enterButtonIcon
+            }
+        } else {
+            enterButtonIcon
         }
+    }
+    
+    private var enterButtonIcon: some View {
+        AppIcon.sendFill.image(
+            width: 28,
+            height: 28,
+            appColor: store.isValidInput ? .orange40 : .gray50
+        )
+        .padding(10)
     }
 }
 
@@ -428,6 +439,7 @@ struct CommentCardView: View {
             commentCard
         } else {
             CommentView.secret
+                .padding(20)
         }
     }
     
@@ -472,7 +484,7 @@ struct CommentCardView: View {
     private var replyList: some View {
         VStack(alignment: .leading, spacing: 0) {
             ForEach(replies) { reply in
-                HStack(alignment: .top, spacing: 8) {
+                HStack(alignment: reply.isVisible ? .top : .center, spacing: 8) {
                     hyphen
                     replyContent(reply)
                 }
@@ -492,7 +504,6 @@ struct CommentCardView: View {
             )
         } else {
             CommentView.secret
-                .padding(20)
         }
     }
     

--- a/Up/Up/Features/Company/Feature/CompanyDetailFeature.swift
+++ b/Up/Up/Features/Company/Feature/CompanyDetailFeature.swift
@@ -234,7 +234,7 @@ struct CompanyDetailView: View {
         AppButton(
             icon: isFollowed ? .followingFill : .followLine,
             style: isFollowed ? .fill : .stroke,
-            text: "팔로우"
+            text: isFollowed ? "팔로잉" : "팔로우"
         ) {
             store.send(.followButtonTapped)
         }

--- a/Up/Up/Features/Company/Feature/CompanyReviewFeature.swift
+++ b/Up/Up/Features/Company/Feature/CompanyReviewFeature.swift
@@ -111,7 +111,7 @@ struct CompanyReviewFeature {
                 }
                 state.reviews[index].likeCount += state.reviews[index].isLiked ? -1 : 1
                 state.reviews[index].isLiked.toggle()
-                return .send(.like(review))
+                return .send(.like(state.reviews[index]))
                     .debounce(
                         id: CancelID.like,
                         for: 1,

--- a/Up/Up/Features/Company/View/CommentView.swift
+++ b/Up/Up/Features/Company/View/CommentView.swift
@@ -66,7 +66,7 @@ struct CommentView: View {
     
     private var secretComment: some View {
         HStack(spacing: 2) {
-            Text("비밀댓글입니다.")
+            Text(originComment == nil ? "비밀댓글입니다." : "비밀답글입니다.")
                 .pretendard(.body2Bold, color: .gray50)
             AppIcon.lockFill.image(
                 width: 14,

--- a/Up/Up/Features/Review/Feature/ReviewPointFeature.swift
+++ b/Up/Up/Features/Review/Feature/ReviewPointFeature.swift
@@ -161,6 +161,7 @@ struct ReviewPointView: View {
                     Text(store.reviewPoints[point] ?? point.placeholder)
                         .pretendard(.body1Regular, color: store.reviewPoints[point] == nil ? .gray50 : .gray90)
                         .multilineTextAlignment(.leading)
+                        .lineLimit(3)
                     Spacer()
                 }
                 .padding(.vertical, 12)

--- a/Up/Up/Features/Search/Feature/SearchFocused.swift
+++ b/Up/Up/Features/Search/Feature/SearchFocused.swift
@@ -14,12 +14,10 @@ struct SearchFocusedFeature {
     struct State: Equatable {
         let searchTerm: String
         let proposedCompanies: [ProposedCompany]
-        var savedCompanies: [SavedCompany] = []
+        var savedCompanies: [SavedCompany]
     }
     
     enum Action {
-        case viewAppear
-        case loadSavedCompanies
         case deleteButtonTapped(SavedCompany)
     }
     
@@ -28,15 +26,6 @@ struct SearchFocusedFeature {
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
-            case .viewAppear:
-                return .send(.loadSavedCompanies)
-                
-            case .loadSavedCompanies:
-                if let savedCompanies = try? userDefaultsService.fetch(key: "savedCompanies", type: [SavedCompany].self) {
-                    state.savedCompanies = savedCompanies
-                }
-                return .none
-                
             case let .deleteButtonTapped(company):
                 if let index = state.savedCompanies.firstIndex(of: company) {
                     state.savedCompanies.remove(at: index)
@@ -54,14 +43,6 @@ struct SearchFocusedView: View {
     let store: StoreOf<SearchFocusedFeature>
     
     var body: some View {
-        searchFocused
-            .onAppear {
-                store.send(.viewAppear)
-            }
-    }
-    
-    @ViewBuilder
-    private var searchFocused: some View {
         if store.searchTerm.isEmpty {
             recentSearchedCompany
         } else {
@@ -188,7 +169,7 @@ struct SearchFocusedView: View {
                 )
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(alignment: .top, spacing: 4) {
-                        Text(company.name)
+                        Text(company.name.withZeroWidthSpaces)
                             .pretendard(.body1Bold, color: .gray90)
                         AppIcon.starFill.image(
                             width: 20,

--- a/Up/Up/Features/Search/Feature/SearchSubmitted.swift
+++ b/Up/Up/Features/Search/Feature/SearchSubmitted.swift
@@ -323,7 +323,7 @@ struct SearchSubmittedView: View {
         VStack(spacing: 40) {
             HStack(alignment: .top, spacing: 0) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(company.name)
+                    Text(company.name.withZeroWidthSpaces)
                         .multilineTextAlignment(.leading)
                         .pretendard(.body1Bold, color: .black)
                     Text(company.address)

--- a/Up/Up/Shared/Feature/TextInputSheetFeature.swift
+++ b/Up/Up/Shared/Feature/TextInputSheetFeature.swift
@@ -190,23 +190,16 @@ struct TextInputSheetView: View {
         HStack {
             Text(store.textCount)
             Spacer()
-            if store.isSaveButtonEnabled {
-                Button {
-                    store.send(.saveButtonTapped)
-                } label: {
-                    saveButtonUI
-                }
-            } else {
-                saveButtonUI
+            Button {
+                store.send(.saveButtonTapped)
+            } label: {
+                Text("저장")
+                    .pretendard(.body1Bold, color: store.isSaveButtonEnabled ? .orange40 : .orange20)
+                    .frame(width: 44, height: 44)
             }
+            .disabled(!store.isSaveButtonEnabled)
         }
         .padding(20)
-    }
-    
-    private var saveButtonUI: some View {
-        Text("저장")
-            .pretendard(.body1Bold, color: store.isSaveButtonEnabled ? .orange40 : .orange20)
-            .frame(width: 44, height: 44)
     }
 }
 

--- a/Up/Up/Shared/Feature/TextInputSheetFeature.swift
+++ b/Up/Up/Shared/Feature/TextInputSheetFeature.swift
@@ -185,19 +185,28 @@ struct TextInputSheetView: View {
         .padding(20)
     }
     
+    @ViewBuilder
     private var controlArea: some View {
         HStack {
             Text(store.textCount)
             Spacer()
-            Button {
-                store.send(.saveButtonTapped)
-            } label: {
-                Text("저장")
-                    .pretendard(.body1Bold, color: store.isSaveButtonEnabled ? .orange40 : .orange20)
-                    .frame(width: 44, height: 44)
+            if store.isSaveButtonEnabled {
+                Button {
+                    store.send(.saveButtonTapped)
+                } label: {
+                    saveButtonUI
+                }
+            } else {
+                saveButtonUI
             }
         }
         .padding(20)
+    }
+    
+    private var saveButtonUI: some View {
+        Text("저장")
+            .pretendard(.body1Bold, color: store.isSaveButtonEnabled ? .orange40 : .orange20)
+            .frame(width: 44, height: 44)
     }
 }
 


### PR DESCRIPTION
- 지번 주소 우선 표시
- 댓글창 입력 버튼 비활성화시 안눌리도록 수정
- 댓글창 입력 불가 문자 입력 못하도록 validator 적용
- 비밀 답글의 경우 하이픈 정렬 위치 센터에 오도록 수정
- 기업 팔로우 여부에 따라 문구 수정
- 기업 상세 화면의 좋아요 로직 수정
- 비밀 댓글인지 답글인지에 따라 문구 수정
- 리뷰 작성 화면의 장,단점 등의 lineLimit을 3으로 수정
- 검색 결과 화면에서 뒤로가기 버튼 나타나고, 취소 버튼 없어지도록 수정
- 열람하여 저장된
 기업이 검색중 사라지는 버그 수정
- 검색 중, 후의 기업 이름을 단어 단위 lineBreak가 아닌 한 글자 단위로 수정
- 텍스트필드 시트의 저장버튼 비활성화시 눌리지 않도록 수정