### PR TITLE
PR: 100 미터 미만 미터로 표시 및 완료 얼럿 추가

### DIFF
--- a/Up/Up/Features/Search/Entity/SearchedCompany.swift
+++ b/Up/Up/Features/Search/Entity/SearchedCompany.swift
@@ -19,7 +19,13 @@ struct SearchedCompany: Equatable, Identifiable {
     var location: String {
         var location: String = String(self.address.prefix(2))
         if let distance = self.distance {
-            let distanceString = String(distance.rounded(to: 1)) + "km"
+            let meter = Int(distance * 1000)
+            let distanceString = if meter >= 100 {
+                String(distance.rounded(to: 1)) + "km"
+            } else {
+                String(meter) + "m"
+            }
+            
             
             if location.isEmpty {
                 location += "\(distanceString)"


### PR DESCRIPTION
- 회원 가입: 로딩 인디케이터, 완료 얼럿 추가
- 정보 수정: 로딩 인디케이터, 완료 얼럿 추가
- 검색된 기업: 거리 표기 km 및 m로 분기처리
- 기업 검색: 테마 버튼을 눌러서 검색 테마를 옮겼을 때 State가 갱신되지만 Store가 갱신되지는 않으므로 기존 작업을 마저 진행하던 문제 수정
    - 즉, 내 주변 검색하다가 우리 동네 검색으로 넘어가도 데이터가 섞이지 않도록 cancellable 추가