### PR TITLE
PR: 위치 요청 시 notDetermined 상태일때 분기처리 로직 추가

### DIFF
--- a/Up/Up/Shared/Service/LocationService.swift
+++ b/Up/Up/Shared/Service/LocationService.swift
@@ -106,13 +106,18 @@ extension LocationService: CLLocationManagerDelegate {
         switch status {
         case .authorizedWhenInUse, .authorizedAlways:
             cont.resume(returning: ())
+            authContinuation = nil
         case .denied:
             cont.resume(throwing: LocationError.authorizationDenied)
+            authContinuation = nil
         case .restricted:
             cont.resume(throwing: LocationError.authorizationRestricted)
+            authContinuation = nil
+        case .notDetermined:
+            break
         default:
             cont.resume(throwing: LocationError.cancelled)
+            authContinuation = nil
         }
-        authContinuation = nil
     }
 }


### PR DESCRIPTION
- notDetermined 상태일때 위치 요청 결과를 받을때까지 대기해야 하는데, 여기서 에러를 던지고 있어서 생긴 문제였습니다.
