### PR TITLE
PR: 심사 대응

### DIFF
--- a/Up/Up/Shared/Utils/KaKaoSignInManager.swift
+++ b/Up/Up/Shared/Utils/KaKaoSignInManager.swift
@@ -13,23 +13,43 @@ final class KaKaoSignInManager {
     static let shared = KaKaoSignInManager()
 
     func signIn() async throws -> String {
-        let token: String = try await withCheckedThrowingContinuation { continuation in
-            UserApi.shared.loginWithKakaoTalk { oauthToken, error in
-                if let error = error {
-                    print(error)
-                    continuation.resume(throwing: error)
-                    return
+        if UserApi.isKakaoTalkLoginAvailable() {
+            let token: String = try await withCheckedThrowingContinuation { continuation in
+                UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+                    if let error = error {
+                        print(error)
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    if let oauthToken {
+                        print("카카오톡 로그인 success \(String(describing: oauthToken.accessToken))")
+                        continuation.resume(returning: oauthToken.accessToken)
+                    } else {
+                        continuation.resume(throwing: NSError(domain: "KaKao Talk Sign In Error with Unknown Reason", code: -1))
+                    }
                 }
-                if let oauthToken {
-                    print("카카오톡 로그인 success \(String(describing: oauthToken.accessToken))")
-                    continuation.resume(returning: oauthToken.accessToken)
-                } else {
-                    continuation.resume(throwing: NSError(domain: "KaKao Sign In Error with Unknown Reason", code: -1))
+                
+            }
+            
+            return token
+        } else {
+            let token: String = try await withCheckedThrowingContinuation { continuation in
+                UserApi.shared.loginWithKakaoAccount { oauthToken, error in
+                    if let error = error {
+                        print(error)
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    if let oauthToken {
+                        print("카카오 계정 로그인 success \(String(describing: oauthToken.accessToken))")
+                        continuation.resume(returning: oauthToken.accessToken)
+                    } else {
+                        continuation.resume(throwing: NSError(domain: "KaKao Account Sign In Error with Unknown Reason", code: -1))
+                    }
                 }
             }
             
+            return token
         }
-        
-        return token
     }
 }


### PR DESCRIPTION
- 애플로그인, 카카오로그인에서 사용자가 로그인을 취소했을 경우, 에러팝업이 뜨지 않도록 분기처리를 하였습니다.
- 카카오톡이 없으면 카카오 계정으로 로그인하기 모달이 뜨도록 로직을 추가하였습니다.